### PR TITLE
Excluded the rootChannel from the GroupView and tried to use channel.name

### DIFF
--- a/index.js
+++ b/index.js
@@ -120,7 +120,7 @@ var searchUserGroups = function(groupString, channel) {
 		groupString = searchUserGroups(groupString, channel.children[i]);
 	} 
 	if(channel !== mumbleClient.rootChannel && channel.users.length > 0){
-		groupString += channel.name + ' Gruppe:\n'; //TODO channel.name?!
+		groupString += channel.name + ' Gruppe:\n';
 		for (var i = 0, len = channel.users.length; i < len; i++){
 			groupString += '    ' + channel.users[i].name + '\n';
 		}

--- a/index.js
+++ b/index.js
@@ -119,8 +119,8 @@ var searchUserGroups = function(groupString, channel) {
 	for (var i = 0, len = channel.children.length; i < len; i++){
 		groupString = searchUserGroups(groupString, channel.children[i]);
 	} 
-	if(channel.users.length > 0){
-		groupString += 'Gruppe:\n'; //TODO channel.name?!
+	if(channel !== mumbleClient.rootChannel && channel.users.length > 0){
+		groupString += channel.name + ' Gruppe:\n'; //TODO channel.name?!
 		for (var i = 0, len = channel.users.length; i < len; i++){
 			groupString += '    ' + channel.users[i].name + '\n';
 		}


### PR DESCRIPTION
- rootChannel (with gemumble_bot in it) will not longer be printed out when using `/gemumble@gemumble_bot`. That results in the fact, that also users idling in the rootChannel will no longer printed out. But in my opinion that's no problem since you can't talk (ore really _use_ Mumble) in the rootChannel.
- I found hints in the mumble-API that there is a `channel.name` property. E.g. [Line 153-158](https://github.com/Rantanen/node-mumble/blob/master/lib/Channel.js). So let's just try it?